### PR TITLE
[HIIT-001] Refactor: 상속하여 구현된 Response 수정

### DIFF
--- a/src/main/java/com/hiit/api/domain/dto/response/it/DayItResponse.java
+++ b/src/main/java/com/hiit/api/domain/dto/response/it/DayItResponse.java
@@ -2,19 +2,25 @@ package com.hiit.api.domain.dto.response.it;
 
 import com.hiit.api.common.marker.dto.response.ServiceResponse;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode
 @AllArgsConstructor
 @NoArgsConstructor
-@SuperBuilder(toBuilder = true)
-public class DayItResponse extends ItResponse implements ServiceResponse {
+@Builder(toBuilder = true)
+public class DayItResponse implements ServiceResponse {
 
 	private Long day;
+
+	private Long id;
+	private String topic;
+	private Long startTime;
+	private Long endTime;
+	private Long participatePerson;
 }

--- a/src/main/java/com/hiit/api/domain/dto/response/it/ItResponse.java
+++ b/src/main/java/com/hiit/api/domain/dto/response/it/ItResponse.java
@@ -2,18 +2,18 @@ package com.hiit.api.domain.dto.response.it;
 
 import com.hiit.api.common.marker.dto.response.ServiceResponse;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
 @EqualsAndHashCode
 @AllArgsConstructor
 @NoArgsConstructor
-@SuperBuilder(toBuilder = true)
+@Builder(toBuilder = true)
 public class ItResponse implements ServiceResponse {
 
 	private Long id;

--- a/src/main/java/com/hiit/api/domain/dto/response/it/MemberInItResponse.java
+++ b/src/main/java/com/hiit/api/domain/dto/response/it/MemberInItResponse.java
@@ -2,19 +2,25 @@ package com.hiit.api.domain.dto.response.it;
 
 import com.hiit.api.common.marker.dto.response.ServiceResponse;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode
 @AllArgsConstructor
 @NoArgsConstructor
-@SuperBuilder(toBuilder = true)
-public class MemberInItResponse extends ItResponse implements ServiceResponse {
+@Builder(toBuilder = true)
+public class MemberInItResponse implements ServiceResponse {
 
 	private Boolean memberIn;
+
+	private Long id;
+	private String topic;
+	private Long startTime;
+	private Long endTime;
+	private Long participatePerson;
 }

--- a/src/main/java/com/hiit/api/domain/dto/response/member/MemberResponse.java
+++ b/src/main/java/com/hiit/api/domain/dto/response/member/MemberResponse.java
@@ -2,24 +2,22 @@ package com.hiit.api.domain.dto.response.member;
 
 import com.hiit.api.common.marker.dto.response.ServiceResponse;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
 @EqualsAndHashCode
 @AllArgsConstructor
 @NoArgsConstructor
-@SuperBuilder(toBuilder = true)
+@Builder(toBuilder = true)
 public class MemberResponse implements ServiceResponse {
 
 	private Long id;
 	private String name;
 	private String comment;
 	private String picture;
-	private Boolean friendStatus;
-	private Boolean banStatus;
 }

--- a/src/main/java/com/hiit/api/domain/dto/response/member/StatusMemberResponse.java
+++ b/src/main/java/com/hiit/api/domain/dto/response/member/StatusMemberResponse.java
@@ -1,20 +1,26 @@
 package com.hiit.api.domain.dto.response.member;
 
+import com.hiit.api.common.marker.dto.response.ServiceResponse;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode
 @AllArgsConstructor
 @NoArgsConstructor
-@SuperBuilder(toBuilder = true)
-public class StatusMemberResponse extends MemberResponse {
+@Builder(toBuilder = true)
+public class StatusMemberResponse implements ServiceResponse {
 
 	private Boolean friendStatus;
 	private Boolean banStatus;
+
+	private Long id;
+	private String name;
+	private String comment;
+	private String picture;
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----
기존에 상속으로 구현된 Response를 수정하였습니다.


🙏 작업
----
**[AS-IS]**
ItResponse, MemberResponse를 상속하여 구현한 Response를 분리되도록 수정하였습니다.

**[TO-BE]**


🙈 PR 참고 사항
----
오브젝트 책을 읽으며 상속은 **타입 계층을 구현하기 위해 사용하는 것**이라는 것을 알았고
현재 Response를 상속한 것은 이에 해당하지 않는다고 생각하였습니다.

---
**오브젝트에서 제시한 상속을 사용하면 좋은 경우**
1. 상속 관계가 is-a 관계를 모델링하는가?
2. 클라이언트 입장에서 부모 클래스 타입으로 자식 클래스를 사용해도 무방한가?
---

위의 두 사항이 모두 만족할 때 상속을 사용하면 좋다고 하였습니다.
하지만 Response의 경우 2번의 경우를 만족하지 않는다는 판단을 하였고 수정하였습니다.

📸 스크린샷
----
해당 부분은 필요하시면 넣어주세요~

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
