### PR TITLE
[HIIT-020] Refactor: Header가 요청에 포함되지 않는 문제

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create Swagger API Spec and Reports
         run: |
-          ./gradlew openapi3
+          ./gradlew generateSwaggerUI
 
       - name: Build with Gradle bootBuildImage, tag, and push image to Amazon ECR
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         asciidoctorVersion = '3.3.2'
         epagesRestDocsApiSpecVersion = '0.16.0'
         sonarqubeVersion = '4.0.0.2929'
+        swaggerUIVersion = '4.11.1'
 
         // dependencies
         jsonwebtokenVersion = '0.11.5'
@@ -28,9 +29,12 @@ plugins {
 
     id "com.diffplug.spotless" version "${spotlessVersion}"
 
-    // code-quality plugins
+    // docs plugins
     id 'org.asciidoctor.jvm.convert' version "${asciidoctorVersion}"
     id 'com.epages.restdocs-api-spec' version "${epagesRestDocsApiSpecVersion}"
+    id 'org.hidetake.swagger.generator' version '2.18.2'
+
+    // code-quality plugins
     id "org.sonarqube" version "${sonarqubeVersion}"
     id 'jacoco'
 }
@@ -112,11 +116,16 @@ dependencies {
     implementation "org.flywaydb:flyway-core:${flywayVersion}"
     implementation 'org.flywaydb:flyway-mysql'
 
-    // swagger
+    // swagger & restdocs
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation "com.epages:restdocs-api-spec-mockmvc:${epagesRestDocsApiSpecVersion}"
+    swaggerUI "org.webjars:swagger-ui:${swaggerUIVersion}"
 }
 
 test {
+    dependsOn spotlessApply
+
     useJUnitPlatform()
 
     testLogging {

--- a/src/test/java/com/hiit/api/web/controller/v1/HiitControllerTest.java
+++ b/src/test/java/com/hiit/api/web/controller/v1/HiitControllerTest.java
@@ -41,10 +41,7 @@ class HiitControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/banners", 0)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/banners", 0).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -54,7 +51,6 @@ class HiitControllerTest {
 												.description("배너 내역")
 												.tag(TAG)
 												.requestSchema(Schema.schema("BannerRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("BannerResponse"))
 												.responseFields(Description.success(SupportDescription.banners()))
 												.build())));
@@ -66,10 +62,7 @@ class HiitControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/notice", 0)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/notice", 0).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -79,7 +72,6 @@ class HiitControllerTest {
 												.description("알림 내역")
 												.tag(TAG)
 												.requestSchema(Schema.schema("NoticeRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("NoticeResponse"))
 												.responseFields(Description.success(SupportDescription.notice()))
 												.build())));
@@ -103,7 +95,6 @@ class HiitControllerTest {
 		mockMvc
 				.perform(
 						post(BASE_URL + "/suggest/its", 0)
-								.header("Authorization", "{{accessToken}}")
 								.content(content)
 								.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
@@ -115,7 +106,6 @@ class HiitControllerTest {
 												.description("잇 제안")
 												.tag(TAG)
 												.requestSchema(Schema.schema("SuggestItsRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("SuggestItsResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -139,7 +129,6 @@ class HiitControllerTest {
 		mockMvc
 				.perform(
 						post(BASE_URL + "/suggest/its", 0)
-								.header("Authorization", "{{accessToken}}")
 								.content(content)
 								.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
@@ -151,7 +140,6 @@ class HiitControllerTest {
 												.description("잇 제안")
 												.tag(TAG)
 												.requestSchema(Schema.schema("SuggestItsRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("SuggestItsResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -174,7 +162,6 @@ class HiitControllerTest {
 		mockMvc
 				.perform(
 						post(BASE_URL + "/suggest/its", 0)
-								.header("Authorization", "{{accessToken}}")
 								.content(content)
 								.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
@@ -186,7 +173,6 @@ class HiitControllerTest {
 												.description("잇 제안")
 												.tag(TAG)
 												.requestSchema(Schema.schema("SuggestItsRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("SuggestItsResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -210,7 +196,6 @@ class HiitControllerTest {
 		mockMvc
 				.perform(
 						post(BASE_URL + "/suggest/its", 0)
-								.header("Authorization", "{{accessToken}}")
 								.content(content)
 								.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
@@ -222,7 +207,6 @@ class HiitControllerTest {
 												.description("잇 제안")
 												.tag(TAG)
 												.requestSchema(Schema.schema("SuggestItsRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("SuggestItsResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -245,7 +229,6 @@ class HiitControllerTest {
 		mockMvc
 				.perform(
 						post(BASE_URL + "/suggest/its", 0)
-								.header("Authorization", "{{accessToken}}")
 								.content(content)
 								.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
@@ -257,7 +240,6 @@ class HiitControllerTest {
 												.description("잇 제안")
 												.tag(TAG)
 												.requestSchema(Schema.schema("SuggestItsRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("SuggestItsResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -281,7 +263,6 @@ class HiitControllerTest {
 		mockMvc
 				.perform(
 						post(BASE_URL + "/suggest/its", 0)
-								.header("Authorization", "{{accessToken}}")
 								.content(content)
 								.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
@@ -293,7 +274,6 @@ class HiitControllerTest {
 												.description("잇 제안")
 												.tag(TAG)
 												.requestSchema(Schema.schema("SuggestItsRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("SuggestItsResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -318,7 +298,6 @@ class HiitControllerTest {
 		mockMvc
 				.perform(
 						post(BASE_URL + "/suggest/its", 0)
-								.header("Authorization", "{{accessToken}}")
 								.content(content)
 								.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
@@ -330,7 +309,6 @@ class HiitControllerTest {
 												.description("잇 제안")
 												.tag(TAG)
 												.requestSchema(Schema.schema("SuggestItsRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("SuggestItsResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -342,10 +320,7 @@ class HiitControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/errors", 0)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/errors", 0).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -355,7 +330,6 @@ class HiitControllerTest {
 												.description("에러 내역")
 												.tag(TAG)
 												.requestSchema(Schema.schema("ErrorsRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("ErrorsResponse"))
 												.responseFields(Description.success(SupportDescription.errors()))
 												.build())));
@@ -367,10 +341,7 @@ class HiitControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/dayCode", 0)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/dayCode", 0).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -380,7 +351,6 @@ class HiitControllerTest {
 												.description("날짜 코드")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DayCodeRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DayCodeResponse"))
 												.responseFields(Description.success(SupportDescription.dayCode()))
 												.build())));

--- a/src/test/java/com/hiit/api/web/controller/v1/end/it/EndItCommandControllerTest.java
+++ b/src/test/java/com/hiit/api/web/controller/v1/end/it/EndItCommandControllerTest.java
@@ -44,11 +44,7 @@ class EndItCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						put(BASE_URL, 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(put(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -58,7 +54,6 @@ class EndItCommandControllerTest {
 												.description("종료 잇 수정한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("EditEndItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EditEndItInfoResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -76,11 +71,7 @@ class EndItCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						put(BASE_URL, 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(put(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -90,7 +81,6 @@ class EndItCommandControllerTest {
 												.description("종료 잇 수정한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("EditEndItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EditEndItInfoResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -106,11 +96,7 @@ class EndItCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						put(BASE_URL, 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(put(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -120,7 +106,6 @@ class EndItCommandControllerTest {
 												.description("종료 잇 수정한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("EditEndItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EditEndItInfoResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -136,11 +121,7 @@ class EndItCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						put(BASE_URL, 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(put(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -150,7 +131,6 @@ class EndItCommandControllerTest {
 												.description("종료 잇 수정한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("EditEndItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EditEndItInfoResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -166,11 +146,7 @@ class EndItCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						put(BASE_URL, 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(put(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -180,7 +156,6 @@ class EndItCommandControllerTest {
 												.description("종료 잇 수정한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("EditEndItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EditEndItInfoResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -198,11 +173,7 @@ class EndItCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						delete(BASE_URL, 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(delete(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -212,7 +183,6 @@ class EndItCommandControllerTest {
 												.description("종료 잇 숨긴다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DeleteEndItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DeleteEndItInfoResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -228,11 +198,7 @@ class EndItCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						put(BASE_URL, 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(put(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -242,7 +208,6 @@ class EndItCommandControllerTest {
 												.description("종료 잇 숨긴다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DeleteEndItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DeleteEndItInfoResponse"))
 												.responseFields(Description.fail())
 												.build())));

--- a/src/test/java/com/hiit/api/web/controller/v1/end/it/EndItQueryControllerTest.java
+++ b/src/test/java/com/hiit/api/web/controller/v1/end/it/EndItQueryControllerTest.java
@@ -41,10 +41,7 @@ class EndItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/{id}", 1)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/{id}", 1).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -55,7 +52,6 @@ class EndItQueryControllerTest {
 												.tag(TAG)
 												.requestSchema(Schema.schema("EndItInfoRequest"))
 												.pathParameters(parameterWithName("id").description("종료 잇 id"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EndItInfoResponse"))
 												.responseFields(Description.success(EndItDescription.browseEndIt()))
 												.build())));
@@ -67,10 +63,7 @@ class EndItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/{id}", -1)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/{id}", -1).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -81,7 +74,6 @@ class EndItQueryControllerTest {
 												.tag(TAG)
 												.requestSchema(Schema.schema("EndItInfoRequest"))
 												.pathParameters(parameterWithName("id").description("종료 잇 id"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EndItInfoResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -93,10 +85,7 @@ class EndItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL, 0).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -106,8 +95,6 @@ class EndItQueryControllerTest {
 												.description("종료 잇 목록")
 												.tag(TAG)
 												.requestSchema(Schema.schema("EndItInfosRequest"))
-												.requestHeaders(Description.authHeader())
-												.responseSchema(Schema.schema("EndItInfosResponse"))
 												.responseFields(Description.success(EndItDescription.readEndIts()))
 												.build())));
 	}
@@ -122,7 +109,6 @@ class EndItQueryControllerTest {
 		mockMvc
 				.perform(
 						get(BASE_URL + "/withs", 0)
-								.header("Authorization", "{{accessToken}}")
 								.queryParam("id", "1")
 								.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
@@ -132,10 +118,8 @@ class EndItQueryControllerTest {
 								resource(
 										ResourceSnippetParameters.builder()
 												.description("종료 잇 윗")
-												.tag(TAG)
 												.requestSchema(Schema.schema("EndWithInfoRequest"))
 												.requestParameters(parameterWithName("id").description("종료 잇 id"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EndWithInfoResponse"))
 												.responseFields(Description.success(EndItDescription.browseEndWith()))
 												.build())));
@@ -149,7 +133,6 @@ class EndItQueryControllerTest {
 		mockMvc
 				.perform(
 						get(BASE_URL + "/withs", 0)
-								.header("Authorization", "{{accessToken}}")
 								.queryParam("id", "-1")
 								.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
@@ -159,10 +142,8 @@ class EndItQueryControllerTest {
 								resource(
 										ResourceSnippetParameters.builder()
 												.description("종료 잇 윗")
-												.tag(TAG)
 												.requestSchema(Schema.schema("EndWithInfoRequest"))
 												.requestParameters(parameterWithName("id").description("종료 잇 id"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EndWithInfoResponse"))
 												.responseFields(Description.fail())
 												.build())));

--- a/src/test/java/com/hiit/api/web/controller/v1/hit/HitCommandControllerTest.java
+++ b/src/test/java/com/hiit/api/web/controller/v1/hit/HitCommandControllerTest.java
@@ -48,11 +48,7 @@ class HitCommandControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						post(BASE_URL, 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(post(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -62,7 +58,6 @@ class HitCommandControllerTest {
 												.description("힛을 수행한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("HitRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("HitResponse"))
 												.responseFields(
 														Description.success(
@@ -85,11 +80,7 @@ class HitCommandControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						post(BASE_URL, 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(post(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -99,7 +90,6 @@ class HitCommandControllerTest {
 												.description("힛을 수행한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("HitRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("HitResponse"))
 												.responseFields(Description.fail())
 												.build())));

--- a/src/test/java/com/hiit/api/web/controller/v1/it/ItCommandControllerTest.java
+++ b/src/test/java/com/hiit/api/web/controller/v1/it/ItCommandControllerTest.java
@@ -51,10 +51,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						post(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						post(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -64,7 +61,6 @@ class ItCommandControllerTest {
 												.description("잇에 참여한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddInItResponse"))
 												.responseFields(Description.created())
 												.build())));
@@ -84,10 +80,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						post(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						post(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -97,7 +90,6 @@ class ItCommandControllerTest {
 												.description("잇에 참여한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddInItResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -117,10 +109,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						post(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						post(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -130,7 +119,6 @@ class ItCommandControllerTest {
 												.description("잇에 참여한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddInItResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -149,10 +137,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						post(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						post(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -162,7 +147,6 @@ class ItCommandControllerTest {
 												.description("잇에 참여한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddInItResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -182,10 +166,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						post(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						post(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -195,7 +176,6 @@ class ItCommandControllerTest {
 												.description("잇에 참여한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddInItResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -216,10 +196,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						post(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						post(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -229,7 +206,6 @@ class ItCommandControllerTest {
 												.description("잇에 참여한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddInItResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -250,11 +226,7 @@ class ItCommandControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						put(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(put(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -264,7 +236,6 @@ class ItCommandControllerTest {
 												.description("잇 참여 정보를 수정한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("EditInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("EditInItResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -284,10 +255,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						delete(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						delete(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -297,7 +265,6 @@ class ItCommandControllerTest {
 												.description("잇 참여를 종료한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DeleteInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DeleteInItResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -315,10 +282,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						delete(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						delete(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -328,7 +292,6 @@ class ItCommandControllerTest {
 												.description("잇 참여를 종료한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DeleteInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DeleteInItResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -344,10 +307,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						delete(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						delete(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -357,7 +317,6 @@ class ItCommandControllerTest {
 												.description("잇 참여를 종료한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DeleteInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DeleteInItResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -373,10 +332,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						delete(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						delete(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -386,7 +342,6 @@ class ItCommandControllerTest {
 												.description("잇 참여를 종료한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DeleteInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DeleteInItResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -403,10 +358,7 @@ class ItCommandControllerTest {
 
 		mockMvc
 				.perform(
-						delete(BASE_URL + "/ins", 0)
-								.content(content)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						delete(BASE_URL + "/ins", 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -416,7 +368,6 @@ class ItCommandControllerTest {
 												.description("잇 참여를 종료한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DeleteInItRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DeleteInItResponse"))
 												.responseFields(Description.success())
 												.build())));

--- a/src/test/java/com/hiit/api/web/controller/v1/it/ItQueryControllerTest.java
+++ b/src/test/java/com/hiit/api/web/controller/v1/it/ItQueryControllerTest.java
@@ -41,10 +41,7 @@ class ItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/{id}", 1)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/{id}", 1).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -54,7 +51,6 @@ class ItQueryControllerTest {
 												.description("잇을 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("ItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.pathParameters(parameterWithName("id").description("잇 id"))
 												.responseSchema(Schema.schema("ItInfoResponse"))
 												.responseFields(Description.success(ItDescription.browseIt()))
@@ -67,10 +63,7 @@ class ItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/{id}", -1)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/{id}", -1).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -80,7 +73,6 @@ class ItQueryControllerTest {
 												.description("잇을 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("ItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.pathParameters(parameterWithName("id").description("잇 id"))
 												.responseSchema(Schema.schema("ItInfoResponse"))
 												.responseFields(Description.fail())
@@ -93,10 +85,7 @@ class ItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL, 0).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -106,7 +95,6 @@ class ItQueryControllerTest {
 												.description("잇 목록을 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("ItInfosRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("ItInfosResponse"))
 												.responseFields(Description.success(ItDescription.readIts()))
 												.build())));
@@ -120,10 +108,7 @@ class ItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/ins", 0)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/ins", 0).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -133,7 +118,6 @@ class ItQueryControllerTest {
 												.description("참여 잇 목록을 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("InItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("InItInfoResponse"))
 												.responseFields(Description.success(ItDescription.readInIts()))
 												.build())));
@@ -145,10 +129,7 @@ class ItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/ins/{id}", 1)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/ins/{id}", 1).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -158,7 +139,6 @@ class ItQueryControllerTest {
 												.description("참여 잇을 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("InItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.pathParameters(parameterWithName("id").description("참여 잇 id"))
 												.responseSchema(Schema.schema("InItInfoResponse"))
 												.responseFields(Description.success(ItDescription.browseInIt()))
@@ -171,10 +151,7 @@ class ItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/ins/{id}", -1)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/ins/{id}", -1).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -184,7 +161,6 @@ class ItQueryControllerTest {
 												.description("참여 잇을 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("InItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.pathParameters(parameterWithName("id").description("참여 잇 id"))
 												.responseSchema(Schema.schema("InItInfoResponse"))
 												.responseFields(Description.fail())
@@ -199,10 +175,7 @@ class ItQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL + "/ins/{id}/motivations", 1)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL + "/ins/{id}/motivations", 1).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -212,7 +185,6 @@ class ItQueryControllerTest {
 												.description("참여 잇 동기부여 정보를 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("ItMotivationsRequest"))
-												.requestHeaders(Description.authHeader())
 												.pathParameters(parameterWithName("id").description("참여 잇 id"))
 												.responseSchema(Schema.schema("ItMotivationsResponse"))
 												.responseFields(Description.success(ItDescription.readItMotivations()))
@@ -226,9 +198,7 @@ class ItQueryControllerTest {
 
 		mockMvc
 				.perform(
-						get(BASE_URL + "/ins/{id}/motivations", -1)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+						get(BASE_URL + "/ins/{id}/motivations", -1).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -238,7 +208,6 @@ class ItQueryControllerTest {
 												.description("참여 잇 동기부여 정보를 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("ItMotivationsRequest"))
-												.requestHeaders(Description.authHeader())
 												.pathParameters(parameterWithName("id").description("참여 잇 id"))
 												.responseSchema(Schema.schema("ItMotivationsResponse"))
 												.responseFields(Description.fail())

--- a/src/test/java/com/hiit/api/web/controller/v1/member/MemberQueryControllerTest.java
+++ b/src/test/java/com/hiit/api/web/controller/v1/member/MemberQueryControllerTest.java
@@ -41,10 +41,7 @@ class MemberQueryControllerTest {
 		// set service mock
 
 		mockMvc
-				.perform(
-						get(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(get(BASE_URL, 0).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -54,7 +51,6 @@ class MemberQueryControllerTest {
 												.description("회원 정보를 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("MemberInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("MemberInfoResponse"))
 												.responseFields(Description.success(MemberDescription.browseMember()))
 												.build())));
@@ -70,7 +66,6 @@ class MemberQueryControllerTest {
 		mockMvc
 				.perform(
 						get(BASE_URL + "/stats/it", 2)
-								.header("Authorization", "{{accessToken}}")
 								.queryParam("id", "1")
 								.queryParam("iid", "1")
 								.contentType(MediaType.APPLICATION_JSON))
@@ -83,7 +78,6 @@ class MemberQueryControllerTest {
 												.description("회원 잇 통계를 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("MemberItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.requestParameters(
 														parameterWithName("id").description("멤버 id"),
 														parameterWithName("iid").description("잇 id"))
@@ -100,7 +94,6 @@ class MemberQueryControllerTest {
 		mockMvc
 				.perform(
 						get(BASE_URL + "/stats/it", 2)
-								.header("Authorization", "{{accessToken}}")
 								.queryParam("id", "-1")
 								.queryParam("iid", "1")
 								.contentType(MediaType.APPLICATION_JSON))
@@ -113,7 +106,6 @@ class MemberQueryControllerTest {
 												.description("회원 잇 통계를 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("MemberItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.requestParameters(
 														parameterWithName("id").description("멤버 id"),
 														parameterWithName("iid").description("잇 id"))
@@ -130,7 +122,6 @@ class MemberQueryControllerTest {
 		mockMvc
 				.perform(
 						get(BASE_URL + "/stats/it", 2)
-								.header("Authorization", "{{accessToken}}")
 								.queryParam("id", "1")
 								.queryParam("iid", "-1")
 								.contentType(MediaType.APPLICATION_JSON))
@@ -143,7 +134,6 @@ class MemberQueryControllerTest {
 												.description("회원 잇 통계를 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("MemberItInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.requestParameters(
 														parameterWithName("id").description("멤버 id"),
 														parameterWithName("iid").description("잇 id"))

--- a/src/test/java/com/hiit/api/web/controller/v1/with/WithCommandControllerTest.java
+++ b/src/test/java/com/hiit/api/web/controller/v1/with/WithCommandControllerTest.java
@@ -44,11 +44,7 @@ class WithCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						post(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.content(content)
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(post(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -58,7 +54,6 @@ class WithCommandControllerTest {
 												.description("윗 추가한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddWithRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddWithResponse"))
 												.responseFields(Description.created())
 												.build())));
@@ -73,11 +68,7 @@ class WithCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						post(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.content(content)
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(post(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -87,7 +78,6 @@ class WithCommandControllerTest {
 												.description("윗 추가한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddWithRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddWithResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -102,11 +92,7 @@ class WithCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						post(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.content(content)
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(post(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -116,7 +102,6 @@ class WithCommandControllerTest {
 												.description("윗 추가한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddWithRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddWithResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -131,11 +116,7 @@ class WithCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						post(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.content(content)
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(post(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -145,7 +126,6 @@ class WithCommandControllerTest {
 												.description("윗 추가한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddWithRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddWithResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -161,11 +141,7 @@ class WithCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						post(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.content(content)
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(post(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -175,7 +151,6 @@ class WithCommandControllerTest {
 												.description("윗 추가한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("AddWithRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("AddWithResponse"))
 												.responseFields(Description.fail())
 												.build())));
@@ -192,11 +167,7 @@ class WithCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						delete(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.content(content)
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(delete(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
@@ -206,7 +177,6 @@ class WithCommandControllerTest {
 												.description("윗 삭제한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DeleteWithRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DeleteWithResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -221,11 +191,7 @@ class WithCommandControllerTest {
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
-				.perform(
-						delete(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
-								.content(content)
-								.contentType(MediaType.APPLICATION_JSON))
+				.perform(delete(BASE_URL, 0).content(content).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is4xxClientError())
 				.andDo(
 						document(
@@ -235,7 +201,6 @@ class WithCommandControllerTest {
 												.description("윗 삭제한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("DeleteWithRequest"))
-												.requestHeaders(Description.authHeader())
 												.responseSchema(Schema.schema("DeleteWithResponse"))
 												.responseFields(Description.fail())
 												.build())));

--- a/src/test/java/com/hiit/api/web/controller/v1/with/WithGetControllerTest.java
+++ b/src/test/java/com/hiit/api/web/controller/v1/with/WithGetControllerTest.java
@@ -42,7 +42,6 @@ class WithGetControllerTest {
 		mockMvc
 				.perform(
 						get(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
 								.queryParam("page", "0")
 								.queryParam("size", "10")
 								.queryParam("sort", "id,desc")
@@ -58,7 +57,6 @@ class WithGetControllerTest {
 												.description("윗 정보 조회를 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("WithInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.requestParameters(
 														parameterWithName("id").description("윗 id"),
 														parameterWithName("my").description("나의 윗 정보 조회 여부"),
@@ -78,7 +76,6 @@ class WithGetControllerTest {
 		mockMvc
 				.perform(
 						get(BASE_URL, 0)
-								.header("Authorization", "{{accessToken}}")
 								.queryParam("page", "0")
 								.queryParam("size", "10")
 								.queryParam("sort", "id,desc")
@@ -94,7 +91,6 @@ class WithGetControllerTest {
 												.description("윗 정보 조회를 조회한다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("WithInfoRequest"))
-												.requestHeaders(Description.authHeader())
 												.requestParameters(
 														parameterWithName("id").description("윗 id"),
 														parameterWithName("my").description("나의 윗 정보 조회 여부"),

--- a/tasks/docs-task.gradle
+++ b/tasks/docs-task.gradle
@@ -1,6 +1,6 @@
 /*convert snippet to swagger*/
 openapi3 {
-    servers = [ { url = "hiit-alb-1485583353.ap-northeast-2.elb.amazonaws.com" } , { url = "http://localhost:8080" }]
+    servers = [ { url = "http://hiit-alb-1485583353.ap-northeast-2.elb.amazonaws.com" } , { url = "http://localhost:8080" }]
     title = "${projectName}"
     version = "${projectVersion}"
     format = 'yaml'
@@ -15,4 +15,27 @@ postman {
     baseUrl = 'http://localhost:8080'
     outputDirectory = "src/main/resources/static/"
     outputFileNamePrefix = 'postman'
+}
+
+swaggerSources {
+    sample {
+        setInputFile(file("src/main/resources/static/openapi3.yaml"))
+    }
+}
+
+tasks.withType(GenerateSwaggerUI) {
+    dependsOn 'openapi3'
+    doFirst {
+        def swaggerUIFile = file("${openapi3.outputDirectory}/openapi3.yaml")
+
+        def securitySchemesContent =  "  securitySchemes:\n" +  \
+                                      "    APIKey:\n" +  \
+                                      "      type: apiKey\n" +  \
+                                      "      name: Authorization\n" +  \
+                                      "      in: header\n" + \
+                                      "security:\n" +
+                "  - APIKey: []  # Apply the security scheme here"
+
+        swaggerUIFile.append securitySchemesContent
+    }
 }


### PR DESCRIPTION
💁‍♂️ PR 내용
----
#33 Header가 요청에 포함되지 않는 문제

🙏 작업
----
Header가 요청에 포함되지 않는 문제 해결

**[AS-IS]**
기존에는 Header가 요청에 포함되지 않는 문제가 있음

**[TO-BE]**
Authorize에 `Bearer {{token}}` 형식으로 Header에 토큰이 포함되도록 해결

🙈 PR 참고 사항
----
아래 링크를 참고 하였습니다.

https://velog.io/@hwsa1004/Spring-restdocs-swagger-%EA%B0%99%EC%9D%B4-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0

📸 스크린샷
----
Swagger 주소
http://hiit-alb-1485583353.ap-northeast-2.elb.amazonaws.com/swagger-ui/index.html

<img width="1446" alt="스크린샷 2023-12-02 오전 12 05 48" src="https://github.com/JNU-econovation/hiit-server/assets/102807742/726edb3f-bca3-4fc6-838f-03b76ede18f2">


🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
